### PR TITLE
Changing TemperatureLow to TemperatureMin

### DIFF
--- a/ImmichFrame.Core/Models/PirateWeather.cs
+++ b/ImmichFrame.Core/Models/PirateWeather.cs
@@ -43,6 +43,9 @@ namespace ImmichFrame.Core.Models
 
         [JsonPropertyName("precipProbability")]
         public double PrecipProbability { get; set; }
+
+        [JsonPropertyName("apparentTemperature")]
+        public double ApparentTemperature { get; set; }
     }
 
     public class Daily
@@ -65,11 +68,11 @@ namespace ImmichFrame.Core.Models
         [JsonPropertyName("icon")]
         public string? Icon { get; set; }
 
-        [JsonPropertyName("temperatureHigh")]
-        public double TemperatureHigh { get; set; }
+        [JsonPropertyName("temperatureMax")]
+        public double TemperatureMax { get; set; }
 
-        [JsonPropertyName("temperatureLow")]
-        public double TemperatureLow { get; set; }
+        [JsonPropertyName("temperatureMin")]
+        public double TemperatureMin { get; set; }
 
         [JsonPropertyName("precipProbability")]
         public double PrecipProbability { get; set; }

--- a/ImmichFrame.Core/Models/Weather.cs
+++ b/ImmichFrame.Core/Models/Weather.cs
@@ -14,6 +14,7 @@ namespace ImmichFrame.Core.Models
         public double TempHigh { get; set; } = 0d;
         public double TempLow { get; set; } = 0d;
         public double Precip { get; set; } = 0d;
+        public double FeelsLike { get; set; } = 0d;
         public DayForecast[] DailyForecast { get; set; } = [];
         public HourForecast[] HourlyForecast { get; set; } = [];
         public Currently Currently { get; set; } = new Currently();

--- a/ImmichFrame.Core/Services/PirateWeatherService.cs
+++ b/ImmichFrame.Core/Services/PirateWeatherService.cs
@@ -50,11 +50,12 @@ namespace ImmichFrame.Core.Services
                 {
                     IconId = data?.Currently?.Icon ?? "",
                     Temperature = data?.Currently?.Temperature ?? 0,
-                    TempHigh = data?.Daily?.Data?[0].TemperatureHigh ?? 0,
-                    TempLow = data?.Daily?.Data?[0].TemperatureLow ?? 0,
+                    TempHigh = data?.Daily?.Data?[0].TemperatureMax ?? 0,
+                    TempLow = data?.Daily?.Data?[0].TemperatureMin ?? 0,
                     Precip = data?.Currently?.PrecipProbability ?? 0,
                     Unit = units == "si" ? "°C" : "°F",
                     Description = summary ?? "",
+                    FeelsLike = data?.Currently?.ApparentTemperature ?? 0,
                     HourlyForecast = data?.Hourly?.Data?.Skip(1).Where((_, index) => index % 2 == 0).Take(6).ToArray() ?? [],
                     DailyForecast = data?.Daily?.Data?.Skip(1).Take(3).ToArray() ?? [],
                 };

--- a/immichFrame.Web/src/lib/components/elements/weather.svelte
+++ b/immichFrame.Web/src/lib/components/elements/weather.svelte
@@ -61,10 +61,13 @@
          
             <div class="current temperature">{weather.temperature?.toFixed(1)}{weather.unit}</div>
         </div>
-        <div id = "weatherHighLow" style="margin-bottom: 10px;" class="text-sm sm:text-sm md:text-md lg:text-xl text-shadow-sm">
+        <div id = "weatherHighLow" style="margin-bottom: 1px;" class="text-sm sm:text-sm md:text-md lg:text-xl text-shadow-sm">
 				<span style="color:#F8DD70;">H {weather.tempHigh?.toFixed(0)}°</span> / <span style="color:#6FC4F5;margin-right:15px">L {weather.tempLow?.toFixed(0)}°</span> 
 				<img style = "display: inline-block;"src="{icons['irain']}" alt="An umbrella"/> {((weather?.precip ?? 0)*100).toFixed(0)}% 
         </div>
+		<div id = "weatherFeelsLike" style="margin-bottom: 10px;" class="text-sm sm:text-sm md:text-md lg:text-xl text-shadow-sm">
+				<span style="color:#F8DD70;font-style: italic;">Feels Like {weather.feelsLike?.toFixed(0)}{weather.unit}</span>
+		</div>
 
         {#if $configStore.showWeatherDescription}
             <p id="weatherdesc" class="text-sm sm:text-sm md:text-md lg:text-xl text-shadow-sm"
@@ -101,9 +104,9 @@
 				<span class="day-name">{forecast.time != null ? new Date(Number(forecast.time) * 1000).toLocaleDateString(undefined, { weekday: 'short' }) : ''}</span>
 				<span class="forecast-icon-container"><img class="forecast-icon" src="{icons[(forecast.icon ?? '').replaceAll('-','')]}" alt="{(forecast.icon ?? '').replaceAll('-','')}"/></span>
 				<span class="temperature-container small">
-					<span class="high-temperature" style="color:#F8DD70;">H {forecast.temperatureHigh !== undefined ? Math.round(forecast.temperatureHigh) : '--'}°</span>
+					<span class="high-temperature" style="color:#F8DD70;">H {forecast.temperatureMax !== undefined ? Math.round(forecast.temperatureMax) : '--'}°</span>
 					<span class="temperature-separator dimmed">/</span>
-					<span class="low-temperature" style="color:#6FC4F5;margin-right:15px">L {forecast.temperatureLow !== undefined ? Math.round(forecast.temperatureLow) : '--'}</span>
+					<span class="low-temperature" style="color:#6FC4F5;margin-right:15px">L {forecast.temperatureMin !== undefined ? Math.round(forecast.temperatureMin) : '--'}</span>
 				</span>
 				<span class="precipitation-container">
 					<span class="pop">{(Number(forecast?.precipProbability ?? 0) * 100).toFixed(0)}%</span>

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -215,8 +215,8 @@ export type ClientSettingsDto = {
 };
 export type DayForecast = {
     time?: string | null;
-    temperatureHigh?: number;
-    temperatureLow?: number;
+    temperatureMax?: number;
+    temperatureMin?: number;
     precipProbability?: string | null;
     icon?: string | null
 };
@@ -236,6 +236,7 @@ export type IWeather = {
     tempHigh?: number;
     tempLow?: number;
     precip?: number;
+    feelsLike?: number;
     dailyForecast?: DayForecast[] | [];
     hourlyForecast?: HourForecast[] | [];
 };


### PR DESCRIPTION
I should read the documentation for pirate weather better.  Changing from high/low to max/min which better reflects the 24hr period a viewer would assume vs. a daytime high / nighttime low set up.

Also added in Feels Like to Current Temp.